### PR TITLE
Use encoding=utf8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ import setuptools
 
 DESCRIPTION = "Awesome Remote Sensing Toolkit based on PaddlePaddle"
 
-with open("README.md", "r") as fh:
+with open("README.md", "r", encoding='utf8') as fh:
     LONG_DESCRIPTION = fh.read()
 
 with open("requirements.txt") as fin:


### PR DESCRIPTION
windows默认中文编码是gbk，所以在执行`setup.py`读入`README.md`内容那一句的时候会报编码错误，所以指定用UTF-8编码。要不和州哥的commits放一个PR一起修复了？